### PR TITLE
feature/driver-login-disponent-status

### DIFF
--- a/client/blokich/src/app/components/form/login-form/login-form.component.html
+++ b/client/blokich/src/app/components/form/login-form/login-form.component.html
@@ -11,6 +11,8 @@
       />
     </div>
 
+    <app-disponent-status [show]="isNextWeekAvailable" />
+
     <form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
       <div class="mb-3">
         <label for="sluzbeniBroj" class="form-label"

--- a/client/blokich/src/app/components/form/login-form/login-form.component.scss
+++ b/client/blokich/src/app/components/form/login-form/login-form.component.scss
@@ -7,8 +7,14 @@
   background-color: #ffffff;
 }
 
-img {
-  max-height: 60px;
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.status-wrapper {
+  margin-bottom: 1rem;
 }
 
 input.ng-invalid.ng-touched {
@@ -28,14 +34,12 @@ button:disabled {
   cursor: not-allowed;
 }
 
-// 📱 Mobile UX poboljšanje
 @media (max-width: 576px) {
   .card {
     padding: 1.5rem !important;
   }
 }
 
-/* 🔧 Uklanja strelice u Chrome, Edge, Safari */
 input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;

--- a/client/blokich/src/app/components/form/login-form/login-form.component.ts
+++ b/client/blokich/src/app/components/form/login-form/login-form.component.ts
@@ -8,27 +8,55 @@ import {
 import { CommonModule } from '@angular/common';
 import { AuthService } from '../../../services/auth.service';
 import { Router } from '@angular/router';
+import { UploadService } from '../../../services/upload.service';
+import { DisponentStatusComponent } from '../../status/disponent-status/disponent-status.component';
+import dayjs from 'dayjs';
+import isoWeek from 'dayjs/plugin/isoWeek';
+
+dayjs.extend(isoWeek);
 
 @Component({
   selector: 'app-login-form',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, DisponentStatusComponent],
   templateUrl: './login-form.component.html',
   styleUrls: ['./login-form.component.scss'],
 })
 export class LoginFormComponent implements OnInit {
   loginForm!: FormGroup;
   isLoading = false;
+  lastDisponentUpload: any;
+  isNextWeekAvailable: boolean = false;
 
   constructor(
     private fb: FormBuilder,
     private authService: AuthService,
+    private uploadService: UploadService,
     private router: Router,
   ) {}
 
   ngOnInit(): void {
     this.loginForm = this.fb.group({
       sluzbeniBroj: ['', [Validators.required, Validators.pattern(/^\d+$/)]],
+    });
+
+    this.uploadService.fetchLastDisponentUpload().subscribe({
+      next: (res) => {
+        const data = res as { brojTjedna: number; godina: number };
+
+        this.lastDisponentUpload = data;
+
+        const aktualniTjedan = dayjs().isoWeek();
+        if (data.brojTjedna === aktualniTjedan + 1) {
+          this.isNextWeekAvailable = true;
+        }
+      },
+      error: (err) => {
+        console.error(
+          'Greška prilikom dohvacanja informacija o posljednjem disponentu:',
+          err,
+        );
+      },
     });
   }
 

--- a/client/blokich/src/app/components/status/disponent-status/disponent-status.component.html
+++ b/client/blokich/src/app/components/status/disponent-status/disponent-status.component.html
@@ -1,0 +1,4 @@
+<div *ngIf="show" class="status-box">
+  <lucide-icon [img]="Info" class="my-icon" [size]="20"></lucide-icon>
+  <span>Dostupan je disponent za naredni tjedan!</span>
+</div>

--- a/client/blokich/src/app/components/status/disponent-status/disponent-status.component.scss
+++ b/client/blokich/src/app/components/status/disponent-status/disponent-status.component.scss
@@ -1,0 +1,18 @@
+.status-box {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: #dbeafe;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: #1e3a8a;
+  margin-bottom: 1rem;
+  line-height: 1;
+}
+
+.my-icon {
+  width: 1.2rem;
+  height: 1.2rem;
+}

--- a/client/blokich/src/app/components/status/disponent-status/disponent-status.component.spec.ts
+++ b/client/blokich/src/app/components/status/disponent-status/disponent-status.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DisponentStatusComponent } from './disponent-status.component';
+
+describe('DisponentStatusComponent', () => {
+  let component: DisponentStatusComponent;
+  let fixture: ComponentFixture<DisponentStatusComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DisponentStatusComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DisponentStatusComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/blokich/src/app/components/status/disponent-status/disponent-status.component.ts
+++ b/client/blokich/src/app/components/status/disponent-status/disponent-status.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LucideAngularModule, Info } from 'lucide-angular';
+
+@Component({
+  selector: 'app-disponent-status',
+  standalone: true,
+  imports: [CommonModule, LucideAngularModule],
+  templateUrl: './disponent-status.component.html',
+  styleUrls: ['./disponent-status.component.scss'],
+})
+export class DisponentStatusComponent {
+  @Input() show: boolean = false;
+
+  readonly Info = Info;
+}

--- a/service/blokich/src/services/sluzba-upload/sluzba-upload.service.ts
+++ b/service/blokich/src/services/sluzba-upload/sluzba-upload.service.ts
@@ -74,7 +74,6 @@ export class SluzbaUploadService {
             }));
 
             // Očisti kolekciju
-            await this.sluzbaModel.deleteMany({});
             await this.sluzbaModel.insertMany(withTimestamps);
 
             // Sprema info o uploadu


### PR DESCRIPTION
This pull request introduces a new feature to display the status of the next week's disponent in the login form. It includes changes to the HTML, SCSS, TypeScript files, and the addition of a new component for the disponent status. 

### New Feature: Disponent Status Display 

* **HTML Changes:**
  - Added the `app-disponent-status` component to the login form template to display the status of the next week's disponent.

* **SCSS Changes:**
  - Updated the login form styles to include a new `.form` class for better layout and a `.status-wrapper` class for margin adjustments.
  - Removed unnecessary comments related to mobile UX and input styling.

* **TypeScript Changes:**
  - Imported necessary services and components (`UploadService`, `DisponentStatusComponent`, and `dayjs` with `isoWeek` plugin) in the `login-form.component.ts`.
  - Implemented logic to fetch the last disponent upload and determine if the next week is available in the `ngOnInit` method of the `LoginFormComponent`.

* **New Component: Disponent Status** 
  - Created `DisponentStatusComponent` with an `@Input()` property to show or hide the status message.
  - Added HTML and SCSS for the `DisponentStatusComponent` to display a styled status box with an icon. [[1]](diffhunk://#diff-b18210b92fbb61c6141e5445274d520b494953d3f3453d01493770532263fd77R1-R4) [[2]](diffhunk://#diff-836afed3e37457d9b0f2626ada534535e1f1c34c13031491c139ef1e2f023dc2R1-R18)
  - Added a unit test for the `DisponentStatusComponent` to ensure it is created successfully.

### Minor Refactoring

* **Service Changes:**
  - Removed the `deleteMany` call in `SluzbaUploadService` to avoid clearing the collection before inserting new data.

Closes #1 #2 