### PR TITLE
fix/lineSchedule-fetch-correct-sluzba-version-from-disponent

### DIFF
--- a/service/blokich/src/services/vozaci-po-liniji-dan/vozaci-po-liniji-dan.service.ts
+++ b/service/blokich/src/services/vozaci-po-liniji-dan/vozaci-po-liniji-dan.service.ts
@@ -37,6 +37,8 @@ export class VozaciPoLinijiService {
       throw new NotFoundException('Disponent za traženi tjedan nije pronađen.');
     }
 
+    const verzijaSluzbe = disponent.verzija_sluzbe;
+
     const radnici: { sluz_broj: number; br_sl: string }[] = [];
     for (const r of disponent.radnici) {
       const br_sl = r[danKey];
@@ -63,6 +65,7 @@ export class VozaciPoLinijiService {
       const sluzbe = await this.sluzbaModel.find({
         linija,
         br_sl: { $regex: `^${r.br_sl}(P*)$`, $options: 'i' },
+        verzija: verzijaSluzbe
       });
 
       for (const sl of sluzbe) {
@@ -121,6 +124,7 @@ export class VozaciPoLinijiService {
     return {
       dan,
       linija,
+      verzija: verzijaSluzbe,
       voze: rezultat,
     };
   }


### PR DESCRIPTION
This pull request includes changes to the `VozaciPoLinijiService` class in the `service/blokich/src/services/vozaci-po-liniji-dan/vozaci-po-liniji-dan.service.ts` file. The changes introduce the `verzijaSluzbe` variable to ensure that the service version is consistently used in the logic.

verzijaSluzbe is being fetched from disponent according to chosen week ensuring lines are coming from correct sluzba.

### Important changes:

* Added `verzijaSluzbe` variable to store the service version from the `disponent` object.
* Included `verzijaSluzbe` in the query criteria for fetching `sluzbe` from the `sluzbaModel`.
* Returned the `verzijaSluzbe` in the final result object of the service method.

Closes #8 