### PR TITLE
feature/add-docker-support-for-python-pdf-extraction-scripts

### DIFF
--- a/service/blokich/python/.dockerignore
+++ b/service/blokich/python/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/service/blokich/python/Dockerfile
+++ b/service/blokich/python/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .


### PR DESCRIPTION
This pull request introduces a Docker setup for the `service/blokich/python` project. It includes the addition of a `.dockerignore` file to optimize the Docker build process and a `Dockerfile` to define the Python-based application environment.

Docker setup:

* [`service/blokich/python/.dockerignore`](diffhunk://#diff-4fdee20c022d7e19b374b42653187ad4feab4de2a3e82f78ac9ce74fdd442320R1-R3): Added patterns to exclude `__pycache__`, `.pyc`, and `.pyo` files from the Docker build context, reducing unnecessary files in the image.
* [`service/blokich/python/Dockerfile`](diffhunk://#diff-eef43d6c10e87b296522881534b652872613cafcbc7d654cdc495f24f9f88c23R1-R8): Created a Dockerfile using the `python:3.11-slim` base image, setting up the working directory, installing dependencies from `requirements.txt`, and copying the application files into the container.

Closes #21