### PR TITLE
fix/remove-excess-whitespace-in-admin-navbar-on-mobile

### DIFF
--- a/client/blokich/src/app/components/navbar/navbar.component.html
+++ b/client/blokich/src/app/components/navbar/navbar.component.html
@@ -3,7 +3,6 @@
     <img src="assets/blokich_logo.png" alt="Blokich" height="30" />
   </a>
 
-  <!-- Hamburger toggler -->
   <button
     class="navbar-toggler"
     type="button"
@@ -16,15 +15,14 @@
     <span class="navbar-toggler-icon"></span>
   </button>
 
-  <!-- Collapse area -->
   <div class="collapse navbar-collapse" id="navbarNav">
+    <!-- VOZAČ -->
     <div
-      class="d-flex flex-column flex-lg-row align-items-center gap-2 w-100 justify-content-between py-3 py-lg-0"
+      *ngIf="role === 'vozac'"
+      class="d-flex flex-column flex-lg-row w-100 align-items-center justify-content-between py-3 py-lg-0"
     >
-      <!-- Lijeva strana navigacije -->
       <div
-        class="d-flex flex-column flex-lg-row gap-2 align-items-center"
-        [ngClass]="{ invisible: role === 'admin', visible: role === 'vozac' }"
+        class="order-1 order-lg-1 d-flex flex-column flex-lg-row gap-2 align-items-center me-lg-auto"
       >
         <button
           class="nav-btn"
@@ -52,10 +50,8 @@
         </button>
       </div>
 
-      <!-- Desna strana (logout i ime) -->
-      <div class="d-flex align-items-center gap-3 pt-2 pt-lg-0 ps-lg-4">
-        <!-- Podaci o vozaču - samo ako je vozač -->
-        <div class="d-flex flex-column" *ngIf="role === 'vozac'">
+      <div class="order-2 order-lg-2 d-flex align-items-center gap-3 pt-2 pt-lg-0 mt-4 mt-lg-0">
+        <div class="d-flex flex-column">
           <span class="driver-name">
             Vozač: <strong>{{ imePrezime }}</strong>
           </span>
@@ -63,10 +59,16 @@
             Službeni broj: <strong>{{ sluzbeniBroj }}</strong>
           </span>
         </div>
-
-        <!-- Gumb za odjavu - za sve -->
         <button class="nav-btn danger-btn" (click)="logout()">Odjava</button>
       </div>
+    </div>
+
+    <!-- ADMIN -->
+    <div
+      *ngIf="role === 'admin'"
+      class="w-100 d-flex justify-content-center justify-content-lg-end align-items-center py-3 py-lg-0"
+    >
+      <button class="nav-btn danger-btn" (click)="logout()">Odjava</button>
     </div>
   </div>
 </nav>


### PR DESCRIPTION
This pull request updates the `navbar.component.html` file to improve the navigation bar by introducing role-based UI elements for "vozac" (driver) and "admin" roles. The changes primarily focus on restructuring the navigation bar's layout and adding conditional rendering based on the user's role.

### Role-based UI updates:

* Added a conditional block (`*ngIf="role === 'vozac'"`) to display a specific layout for users with the "vozac" role, including the driver's name and official number, and adjusted the layout classes for better alignment and responsiveness. [[1]](diffhunk://#diff-cc7745e6ee7961e935e5d81a743b4d71576b04444f7303c9504cf1bf55b89acaL19-R25) [[2]](diffhunk://#diff-cc7745e6ee7961e935e5d81a743b4d71576b04444f7303c9504cf1bf55b89acaL55-R72)
* Added a separate conditional block (`*ngIf="role === 'admin'"`) to display a simplified layout for users with the "admin" role, including only a logout button.

### Code cleanup:

* Removed outdated or redundant comments, such as "Hamburger toggler" and "Collapse area," to improve code readability. [[1]](diffhunk://#diff-cc7745e6ee7961e935e5d81a743b4d71576b04444f7303c9504cf1bf55b89acaL6) [[2]](diffhunk://#diff-cc7745e6ee7961e935e5d81a743b4d71576b04444f7303c9504cf1bf55b89acaL19-R25) [[3]](diffhunk://#diff-cc7745e6ee7961e935e5d81a743b4d71576b04444f7303c9504cf1bf55b89acaL55-R72)

Closes #26 