### PR TITLE
feat(line-details): open line details in new tab when clicking on lin…

### DIFF
--- a/client/blokich/src/app/components/card/line-duty-card/line-duty-card.component.html
+++ b/client/blokich/src/app/components/card/line-duty-card/line-duty-card.component.html
@@ -2,7 +2,7 @@
   <div class="header">
     <div class="ime">{{ vozac.ime_prezime }}</div>
     <div class="broj">{{ vozac.sluz_broj }}</div>
-    <span class="badge bg-dark">{{vozac.br_sl}}</span>
+    <span class="badge bg-dark">{{ vozac.br_sl }}</span>
   </div>
 
   <div class="details">
@@ -18,7 +18,18 @@
 
     <div class="line-info" *ngIf="vozac['V.R']">
       <span class="vr-label">Linija:</span>
-      <span class="badge bg-accent1">{{vozac.linija}}</span>
+      <a
+        class="badge bg-accent1"
+        [href]="
+          'https://triglav.bezdomni.net/public_transport/zet/routes/' +
+          vozac.linija
+        "
+        target="_blank"
+        rel="noopener noreferrer"
+        style="text-decoration: none; color: inherit"
+      >
+        {{ vozac.linija }}
+      </a>
       <span class="vr-label">V.R:</span>
       <span class="badge bg-accent2">{{ vozac["V.R"] }}</span>
     </div>

--- a/client/blokich/src/app/components/card/weekly-schedule-card/on-duty-card/on-duty-card.component.html
+++ b/client/blokich/src/app/components/card/weekly-schedule-card/on-duty-card/on-duty-card.component.html
@@ -1,5 +1,4 @@
 <div class="duty-card" [ngClass]="getDayClass()">
-
   <div class="duty-header">
     <div class="dan d-flex align-items-center gap-1">
       {{ dan }}
@@ -9,33 +8,47 @@
         class="btn p-0 border-0 bg-transparent"
         tabindex="0"
         *ngIf="!brojSluzbe.includes('P')"
-        [appPopover]="'<b>Ukup. sati: </b>' + ukupSati +
-              '<br><b>Efek. sati: </b>' + efekSati +
-              '<br><b>Dr. smj.: </b>' + drSmj +
-              '<br><b>Noćni rad: </b>' + nocniRad"
-
-        [popoverTitle]="'Detalji smjene'">
+        [appPopover]="
+          '<b>Ukup. sati: </b>' +
+          ukupSati +
+          '<br><b>Efek. sati: </b>' +
+          efekSati +
+          '<br><b>Dr. smj.: </b>' +
+          drSmj +
+          '<br><b>Noćni rad: </b>' +
+          nocniRad
+        "
+        [popoverTitle]="'Detalji smjene'"
+      >
         <lucide-icon [img]="ClockIcon" class="my-icon"></lucide-icon>
       </button>
     </div>
     <div class="datum">{{ datum }}</div>
   </div>
 
-
-  <div class="vrijeme">
-    {{ vrijemePocetak }} – {{ vrijemeKraj }}
-  </div>
+  <div class="vrijeme">{{ vrijemePocetak }} – {{ vrijemeKraj }}</div>
 
   <div class="info">
     <span>Linija:</span>
-    <span class="badge bg-accent1">{{ linija }}</span>
+    <a
+      class="badge bg-accent1"
+      [href]="
+        'https://triglav.bezdomni.net/public_transport/zet/routes/' + linija
+      "
+      target="_blank"
+      rel="noopener noreferrer"
+      style="text-decoration: none; color: inherit"
+    >
+      {{ linija }}
+    </a>
     <span class="vr-label">V.R:</span>
     <span class="badge bg-accent2">{{ vr }}</span>
   </div>
 
-  <div class="nastup">Nastup:
-    <div class="badge light">{{ nastup }}</div> →
-    <div class="badge light" > {{zavrsetak }}</div>
+  <div class="nastup">
+    Nastup:
+    <div class="badge light">{{ nastup }}</div>
+    →
+    <div class="badge light">{{ zavrsetak }}</div>
   </div>
-
 </div>


### PR DESCRIPTION
This pull request introduces improvements to the user interface in two components by adding clickable links for route information and refactoring HTML for better readability and maintainability. The most important changes include adding external links for route details and reformatting HTML attributes and bindings.

### Enhancements to route information:

* In `line-duty-card.component.html`, the `linija` badge is now a clickable link that opens the corresponding route information in a new tab. The link points to the `triglav.bezdomni.net` domain and includes accessibility attributes like `rel="noopener noreferrer"`.
* In `on-duty-card.component.html`, the `linija` badge was similarly updated to be a clickable link with the same behavior and styling as in the `line-duty-card` component.

### Code formatting and readability improvements:

* Reorganized and reformatted the `appPopover` attribute bindings in `on-duty-card.component.html` to improve readability by breaking long strings into multiple lines.
* Removed unnecessary blank lines and adjusted spacing in `on-duty-card.component.html` to improve the overall structure and maintainability of the file. [[1]](diffhunk://#diff-21706482d7ca8bad8118aa4690c8ef61b33f016a2a13efec280669c733b889b0L2) [[2]](diffhunk://#diff-21706482d7ca8bad8118aa4690c8ef61b33f016a2a13efec280669c733b889b0L12-L40)

Closes #32 