### PR TITLE
release: merge develop into main

### DIFF
--- a/client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.html
+++ b/client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.html
@@ -35,6 +35,7 @@
       <h6 class="mb-0" *ngIf="prikazaniTjedan">
         Tjedan {{ prikazaniTjedan }} / {{ prikazanaGodina }}
       </h6>
+      <h6 class="mb-0">[datum] = "datum"</h6>
     </div>
   </div>
 

--- a/client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.html
+++ b/client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.html
@@ -33,9 +33,9 @@
       </div>
 
       <h6 class="mb-0" *ngIf="prikazaniTjedan">
-        Tjedan {{ prikazaniTjedan }} / {{ prikazanaGodina }}
+        Tjedan {{ prikazaniTjedan }} / {{ prikazanaGodina }} ,
+        {{ datum }}
       </h6>
-      <h6 class="mb-0">{{ datum }}</h6>
     </div>
   </div>
 

--- a/client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.html
+++ b/client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.html
@@ -35,7 +35,7 @@
       <h6 class="mb-0" *ngIf="prikazaniTjedan">
         Tjedan {{ prikazaniTjedan }} / {{ prikazanaGodina }}
       </h6>
-      <h6 class="mb-0">[datum] = "datum"</h6>
+      <h6 class="mb-0">{{ datum }}</h6>
     </div>
   </div>
 

--- a/client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.ts
+++ b/client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.ts
@@ -45,6 +45,7 @@ export class WeeklyScheduleComponent
   rasporedZaPrikaz: RasporedDan[] = [];
   prikazaniTjedan: number | null = null;
   prikazanaGodina: number | null = null;
+  datum = dayjs().format('DD.MM.YYYY');
 
   ngOnInit() {
     this.dataDisplay();


### PR DESCRIPTION
This pull request updates the `WeeklyScheduleComponent` to display the current date alongside the week and year in the weekly schedule view. The main changes involve adding a new `datum` property to the component and updating the template to include this property.

### Updates to the Weekly Schedule Display:

* [`client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.ts`](diffhunk://#diff-abb7329bbb198212b8e338415812bdf8c4c07c183b73fae299a083c8695354faR48): Added a new `datum` property initialized with the current date in `DD.MM.YYYY` format using the `dayjs` library.

* [`client/blokich/src/app/components/schedule/weekly-schedule/weekly-schedule.component.html`](diffhunk://#diff-07e281af79a139a92cfe0c0d0d6cf3ae8178f0cfcdfca3fd86400237006b2c0bL36-R37): Updated the template to display the `datum` property alongside the week and year.